### PR TITLE
Cookie jar allows multiple cookies under the same host

### DIFF
--- a/src/peridot/cookie_jar.clj
+++ b/src/peridot/cookie_jar.clj
@@ -43,10 +43,10 @@
 (defn merge-cookies [headers cookie-jar uri host]
   (let [cookie-string (get headers "Set-Cookie")]
     (if cookie-string
-      (assoc cookie-jar host
-         (reduce #(set-cookie %1 (build-cookie %2 uri host))
-                 {}
-                 cookie-string))
+      (if (empty? cookie-string)
+        (dissoc cookie-jar host)
+        (update-in cookie-jar [host] merge
+                   (into {} (map #(build-cookie % uri host) cookie-string))))
       cookie-jar)))
 
 (defn cookies-for [cookie-jar scheme uri host]


### PR DESCRIPTION
I was unable to use peridot (while using kerodon) with a site that used multiple cookies per domain. A response from a handler with a "Set-Cookie" header now adds the new cookie to the cookie jar for the host, rather than replacing the whole cookie jar for the host with the new cookie.
