### PR TITLE
POST parameters are sent in the query-string

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/xeqi/peridot"
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.3.0"]
-                 [ring-mock "0.1.1"]
+                 [ring-mock "0.1.3"]
                  [org.clojure/data.codec "0.1.0"]
                  [org.apache.httpcomponents/httpmime "4.1.3"]]
   :profiles {:test {:dependencies [[net.cgrand/moustache "1.1.0"

--- a/src/peridot/request.clj
+++ b/src/peridot/request.clj
@@ -39,11 +39,12 @@
 (defn build [uri env headers cookie-jar content-type]
   (let [env (apply hash-map env)
         params (:params env)
+        method (:request-method env :get)
         request (if (multipart/multipart? params)
                   (merge-with merge
                               (multipart/build params)
-                              (mock/request :get uri))
-                  (mock/request :get uri params))]
+                              (mock/request method uri))
+                  (mock/request method uri params))]
     (-> request
         (add-headers (-> headers
                          (merge (cj/cookies-for cookie-jar

--- a/test/peridot/test/core.clj
+++ b/test/peridot/test/core.clj
@@ -45,7 +45,25 @@
       (doto
           (#(is (= (:content-type (:request %))
                    "application/x-www-form-urlencoded")
-                 "request uses urlencoded content-type for post")))
+                "request uses urlencoded content-type for post"))
+        (#(is (= (:request-method (:request %))
+                 :post)
+              "request uses post verb as the :request-method")))
+      (request "/" :request-method :post
+               :params {"foo" "bar"
+                        "zoo" "car"})
+      (doto
+          (#(is (= (:content-type (:request %))
+                   "application/x-www-form-urlencoded")
+                "request uses urlencoded content-type"))
+        (#(is (= (:request-method (:request %))
+                 :post)
+              "request uses post verb as the :request-method"))
+        (#(is (not (nil? (:body (:request %))))
+              "request has a body of content"))
+        (#(is (= (slurp (:body (:request %)))
+                 "foo=bar&zoo=car")
+              "request body reflects the parameters")))
       (request "/"
                :request-method :post
                :content-type "application/xml")


### PR DESCRIPTION
Peridot is hardcoded to craft the mock requests it sends using :get as the http verb keyword when it asks ring-mock for a request map. When peridot is making POST requests to send to the ring app in the presence of http parameters, this results in two problems:

1) It incorrectly encodes the parameters in the query string that gets sent to the ring application.
2) It incorrectly omits the parameters from the request body, and submits a POST with a blank body to the ring application.

The version of ring-mock peridot currently relies on in master does not correctly address verbs other than :get when handling parameters, however @weavejester has recently released version 0.1.3 of ring-mock which correctly does handle post parameters as part of the request body.

This pull request:
- Upgrades the ring-mock dependency to 0.1.3
- Adds tests demonstrating the incorrect handling of parameters on the master branch when the verb is post.
- Includes a bug fix to peridot.request/build which propogates the HTTP verb down to ring-mock if present, and defaults to GET if it is not present.
