### PR TITLE
Use `server-port` rather than `port` in `url` function

### DIFF
--- a/src/peridot/request.clj
+++ b/src/peridot/request.clj
@@ -66,12 +66,12 @@
         set-post-content-type
         set-https-port)))
 
-(defn url [{:keys [scheme server-name port uri query-string]}]
+(defn url [{:keys [scheme server-name server-port uri query-string]}]
   (str (name scheme)
        "://"
        server-name
-       (when (and port
-                  (not= port (scheme {:https 443 :http 80})))
-         (str ":" port))
+       (when (and server-port
+                  (not= server-port (scheme {:https 443 :http 80})))
+         (str ":" server-port))
        uri
        query-string))

--- a/test/peridot/test/request.clj
+++ b/test/peridot/test/request.clj
@@ -1,0 +1,9 @@
+(ns peridot.test.request
+  (:use [peridot.request]
+        [clojure.test])
+  (:require [ring.mock.request :as mock]))
+
+(deftest url-generation
+  (testing "it should construct a URI from a ring reqeust"
+    (is (= "http://example.com:4000/fuzbats"
+           (url (mock/request :get "http://example.com:4000/fuzbats"))))))


### PR DESCRIPTION
`server-port` is correct, per the ring spec:

https://github.com/mmcgrana/ring/blob/master/SPEC
