### PR TITLE
Update cookie expiry time parsing to meet HTTP spec

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
                                     :exclusions
                                     [[org.clojure/clojure]
                                      [ring/ring-core]]]
-                                   [ring/ring-core "1.0.2"]]
+                                   [ring/ring-core "1.1.8"]]
                     :resource-paths ["test-resources"]}
              :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}}


### PR DESCRIPTION
I noticed this when passing a clj-time object to ring's wrap-cookies - the date format it generated was rejected by peridot.

I've updated the date parsing, and fleshed out the tests a bit.
