### PR TITLE
Support lists in param maps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.3.0"]
-                 [ring-mock "0.1.3"]
+                 [ring-mock "0.1.4"]
                  [org.clojure/data.codec "0.1.0"]
                  [org.apache.httpcomponents/httpmime "4.1.3"
                   :exclusions [commons-logging]]]

--- a/test/peridot/test/core.clj
+++ b/test/peridot/test/core.clj
@@ -34,6 +34,11 @@
           (#(is (= (:query-string (:request %))
                    "foo=bar&zoo=car")
                 "request sends keyword params")))
+      (request "/" :params {"list" ["a" "b" "c"]})
+      (doto
+        (#(is (= (:query-string (:request %))
+                 "list=a&list=b&list=c")
+              "request sends lists of params")))
       (request "/redirect")
       (doto
           (#(is (= (:status (:response %)) 302)
@@ -64,6 +69,12 @@
         (#(is (= (slurp (:body (:request %)))
                  "foo=bar&zoo=car")
               "request body reflects the parameters")))
+      (request "/" :request-method :post
+               :params {"list" ["a" "b" "c"]})
+      (doto
+        (#(is (= (slurp (:body (:request %)))
+                 "list=a&list=b&list=c")
+              "request body can send lists of params")))
       (request "/"
                :request-method :post
                :content-type "application/xml")


### PR DESCRIPTION
This is a precursor to some of the work I'm doing in the form support in peridot.

It allows param maps to use a vector to supply multiple values for a single key, which then expands to a form that ring's param middleware will handle.

I wanted to get a quick review rather than just dropping it straight into the upstream branch :)
