### PR TITLE
Keep params in request hash.

### DIFF
--- a/src/peridot/request.clj
+++ b/src/peridot/request.clj
@@ -61,7 +61,7 @@
                                                 (get-host request)))
                          (merge (:headers env))))
         (set-content-type content-type)
-        (add-env (dissoc (dissoc env :params) :headers))
+        (add-env (dissoc env :headers))
         (update-in [:body] to-input-stream)
         set-post-content-type
         set-https-port)))


### PR DESCRIPTION
Currently the `:params` hash gets removed from the request hash and the call to ring mock does not add it back although it does some processing of `:params`. This fixes that so you can act on the values in `:params` in your handlers during tests.
