### PR TITLE
Coerce content-length header to string

### DIFF
--- a/src/peridot/multipart.clj
+++ b/src/peridot/multipart.clj
@@ -48,4 +48,4 @@
      :content-length (.getContentLength mpe)
      :content-type (.getValue (.getContentType mpe))
      :headers {"content-type"  (.getValue (.getContentType mpe))
-               "content-length" (.getContentLength mpe)}}))
+               "content-length" (str (.getContentLength mpe))}}))


### PR DESCRIPTION
Ring Spec requires all header values to be strings.

https://github.com/mmcgrana/ring/blob/890ffee2e9d57a55a35804745fd1fee9205dc29c/SPEC#L83-L86

Closes #25