### PR TITLE
Fixed concurrency bug in peridot.multipart

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,9 +8,11 @@
                  [org.clojure/clojure "1.3.0"]
                  [ring-mock "0.1.5"]
                  [org.clojure/data.codec "0.1.0"]
-                 [org.apache.httpcomponents/httpmime "4.1.3"
+                 [org.apache.httpcomponents/httpmime "4.3"
                   :exclusions [commons-logging]]
+                 [org.apache.httpcomponents/httpcore "4.4"]
                  [clj-time "0.9.0"]]
+
   :profiles {:dev {:dependencies [[net.cgrand/moustache "1.1.0"
                                     :exclusions
                                     [[org.clojure/clojure]

--- a/src/peridot/multipart.clj
+++ b/src/peridot/multipart.clj
@@ -3,8 +3,7 @@
   (:import org.apache.http.entity.mime.MultipartEntity
            org.apache.http.entity.mime.content.StringBody
            org.apache.http.entity.mime.content.FileBody
-           java.io.PipedOutputStream
-           java.io.PipedInputStream
+           java.io.ByteArrayOutputStream
            java.io.File
            java.nio.charset.Charset
            javax.activation.FileTypeMap))
@@ -40,12 +39,13 @@
 
 (defn build [params]
   (let [mpe (entity params)]
-    {:body (let [in (PipedInputStream.)
-                 out (PipedOutputStream. in)]
-             (future (do (.writeTo mpe out)
-                         (.close out)))
-             in)
+     {:body (let [out (ByteArrayOutputStream.)]
+                        (.writeTo mpe out)
+                        (.close out)
+                        (.toString out))
+
      :content-length (.getContentLength mpe)
      :content-type (.getValue (.getContentType mpe))
      :headers {"content-type"  (.getValue (.getContentType mpe))
                "content-length" (str (.getContentLength mpe))}}))
+

--- a/src/peridot/multipart.clj
+++ b/src/peridot/multipart.clj
@@ -3,6 +3,7 @@
   (:import org.apache.http.entity.mime.MultipartEntity
            org.apache.http.entity.mime.content.StringBody
            org.apache.http.entity.mime.content.FileBody
+           org.apache.http.entity.ContentType
            java.io.ByteArrayOutputStream
            java.io.File
            java.nio.charset.Charset
@@ -23,8 +24,9 @@
 (defmethod add-part File [m k f]
   (.addPart m
             (ensure-string k)
-            (FileBody. f (.getContentType (FileTypeMap/getDefaultFileTypeMap)
-                                          f))))
+            (FileBody. f (ContentType/create 
+                           (.getContentType (FileTypeMap/getDefaultFileTypeMap) f))
+                       (.getName f))))
 
 (defmethod add-part :default [m k v]
   (.addPart m


### PR DESCRIPTION
Hey!,

We were faithfully writing some tests using peridot against a compojure-api function that accept files over multipart http requests.

After a day and a half of investigation, we narrowed it down to two aspects:

1. Within peridot.multipart, the file contents are wrapped in Piped{In,Out}putStreams within a `future` call. This caused a heinsebug; running it in the repl, sometimes the file would be sent and sometimes it wouldn't. We removed the call to `future` and replaced the Piped streams with a ByteArray that gets dumped to String.

  Not sure why you needed the call to `future` in the first place, and hopefully it doesn't matter for your use case.

2. We then discovered that our requests kept failing because the parsed request, for whatever reason, don't conform to how compojure-api expect multipart headers to conform. We determined that the sent headers lacked a "filename" attribute. We discovered that by modifying how the "file part" gets added to the `MultipartEntity` we were able to get tests on our end to pass.

I hope this can be helpful for others.

Regards,