### PR TITLE
Fixing compiler warnings with typehints

### DIFF
--- a/src/peridot/cookie_jar.clj
+++ b/src/peridot/cookie_jar.clj
@@ -2,7 +2,8 @@
   (:import java.text.SimpleDateFormat
            java.text.ParseException
            java.lang.RuntimeException
-           java.util.Date)
+           java.util.Date
+           (java.text DateFormat))
   (:require [clojure.string :as string]
             [clj-time.core :as t]
             [clj-time.format :as tf]))
@@ -14,9 +15,9 @@
 
 (defn ^:private parse-date
   "Try valid HTTP date formats until we get a date"
-  [date]
+  [^String date]
   (or (some
-        (fn [format]
+        (fn [^DateFormat format]
           (try
             (.parse format date)
             ; Clojure 1.3 wraps the ParseException in a RuntimeException

--- a/src/peridot/core.clj
+++ b/src/peridot/core.clj
@@ -39,9 +39,9 @@
   "Set basic autorization to be used in future requests."
   [state user pass]
   (header state "authorization" (str "Basic "
-                                     (String. (base64/encode
-                                                (.getBytes (str user ":" pass)
-                                                           "UTF-8"))
+                                     (String. ^"[B" (base64/encode
+                                                      (.getBytes (str user ":" pass)
+                                                                 "UTF-8"))
                                               "UTF-8"))))
 (defn- expand-location
   "Expand a location header into an absolute url"

--- a/src/peridot/multipart.clj
+++ b/src/peridot/multipart.clj
@@ -21,7 +21,7 @@
 (defmulti add-part
   (fn [multipartentity key value] (type value)))
 
-(defmethod add-part File [m k f]
+(defmethod add-part File [m k ^File f]
   (.addPart m
             (ensure-string k)
             (FileBody. f (ContentType/create 
@@ -40,7 +40,7 @@
     mpe))
 
 (defn build [params]
-  (let [mpe (entity params)]
+  (let [^MultipartEntity mpe (entity params)]
      {:body (let [out (ByteArrayOutputStream.)]
                         (.writeTo mpe out)
                         (.close out)

--- a/src/peridot/request.clj
+++ b/src/peridot/request.clj
@@ -9,7 +9,7 @@
 (defmulti to-input-stream class)
 
 (defmethod to-input-stream nil [_] nil)
-(defmethod to-input-stream String [s] (-> s .getBytes ByteArrayInputStream.))
+(defmethod to-input-stream String [^String s] (ByteArrayInputStream. (.getBytes s)))
 (defmethod to-input-stream :default [x] (io/input-stream x))
 
 (defn get-host [request]

--- a/test/peridot/test/cookie_jar.clj
+++ b/test/peridot/test/cookie_jar.clj
@@ -1,5 +1,6 @@
 (ns peridot.test.cookie-jar
-  (:import java.util.Date)
+  (:import java.util.Date
+           (java.text DateFormat))
   (:use [peridot.core]
         [clojure.test])
   (:require [clojure.string :as str]
@@ -19,7 +20,7 @@
               (seq m))))
 
 (def expired-date
-  (.format (first cj/cookie-date-formats) (java.util.Date. 0)))
+  (.format ^DateFormat (first cj/cookie-date-formats) (Date. 0)))
 
 (defn expire-cookie [m]
   (assoc m :expires expired-date :value ""))
@@ -169,12 +170,12 @@
 (deftest cookie-expires
   (let [hour-ago (t/from-now (t/hours -1))
         ; See http://tools.ietf.org/html/rfc2616#section-3.3.1
-        params {"rfc822" (tf/unparse (:rfc822 tf/formatters) hour-ago)
-                "rfc850" (tf/unparse
-                           (tf/formatter "EEEE, dd-MMM-yy HH:mm:ss z")
-                           hour-ago)}
-        state (-> (session app)
-                  (request "/expirable/set" :params params))]
+        params   {"rfc822" (tf/unparse (:rfc822 tf/formatters) hour-ago)
+                  "rfc850" (tf/unparse
+                             (tf/formatter "EEEE, dd-MMM-yy HH:mm:ss z")
+                             hour-ago)}
+        state    (-> (session app)
+                     (request "/expirable/set" :params params))]
     (-> state
         (request "/expirable/show")
         (doto
@@ -184,9 +185,9 @@
         rfc822date (tf/unparse (:rfc822 tf/formatters) hour-ahead)
         rfc850date (tf/unparse (tf/formatter "EEEE, dd-MMM-yy HH:mm:ss z")
                                hour-ahead)
-        params {"rfc822" rfc822date, "rfc850" rfc850date}
-        state (-> (session app)
-                  (request "/expirable/set" :params params))]
+        params     {"rfc822" rfc822date, "rfc850" rfc850date}
+        state      (-> (session app)
+                       (request "/expirable/set" :params params))]
     (-> state
         (request "/expirable/show")
         (doto


### PR DESCRIPTION
Cleaning up some unused requires and fixing compiler warnings due to missing type hints when *warn-on-reflection* is enabled.