### PR TITLE
Make per-request content-type settings transient.

### DIFF
--- a/src/peridot/core.clj
+++ b/src/peridot/core.clj
@@ -12,8 +12,8 @@
   "Send a request to the ring app, returns state containing :response and :request sent to and returned from the ring app."
   [{:keys [app headers cookie-jar content-type]} uri & env]
   (let [env (apply hash-map env)
-        content-type (or (:content-type env) content-type)
-        request (pr/build uri env headers cookie-jar content-type)
+        request-content-type (or (:content-type env) content-type)
+        request (pr/build uri env headers cookie-jar request-content-type)
         response (app request)]
     (session app
              :response response

--- a/test/peridot/test/core.clj
+++ b/test/peridot/test/core.clj
@@ -216,6 +216,10 @@
       (doto
         (#(is (= (:content-type (:request %)) "application/xml")
               "content-type is overwritten by the request")))
+      (request "/")
+      (doto
+        (#(is (= (:content-type (:request %)) "application/json")
+              "request content-type is for that request only")))
       (content-type "text/plain")
       (request "/")
       (doto


### PR DESCRIPTION
Setting content-type for a particular request, e.g.,

    (request "/" :content-type "application/json")

should only set the content-type for that request.

Change-Id: Ifb3db6b51645e569ce77f9242889323a1f37e81f