### PR TITLE
Parse dates independent of system locale

### DIFF
--- a/src/peridot/cookie_jar.clj
+++ b/src/peridot/cookie_jar.clj
@@ -2,14 +2,14 @@
   (:import java.text.SimpleDateFormat
            java.text.ParseException
            java.lang.RuntimeException
-           java.util.Date
-           (java.text DateFormat))
+           (java.text DateFormat)
+           (java.util Date Locale))
   (:require [clojure.string :as string]
             [clj-time.core :as t]
             [clj-time.format :as tf]))
 
 (def cookie-date-formats
-  (map #(SimpleDateFormat. %)
+  (map #(SimpleDateFormat. % Locale/US)
        ["EEE, dd MMM yyyy HH:mm:ss z"
         "EEEE, dd-MMM-yy HH:mm:ss z"]))
 

--- a/test/peridot/test/cookie_jar.clj
+++ b/test/peridot/test/cookie_jar.clj
@@ -1,6 +1,6 @@
 (ns peridot.test.cookie-jar
-  (:import java.util.Date
-           (java.text DateFormat))
+  (:import (java.text DateFormat)
+           (java.util Date Locale))
   (:use [peridot.core]
         [clojure.test])
   (:require [clojure.string :as str]
@@ -172,7 +172,7 @@
         ; See http://tools.ietf.org/html/rfc2616#section-3.3.1
         params   {"rfc822" (tf/unparse (:rfc822 tf/formatters) hour-ago)
                   "rfc850" (tf/unparse
-                             (tf/formatter "EEEE, dd-MMM-yy HH:mm:ss z")
+                             (tf/with-locale (tf/formatter "EEEE, dd-MMM-yy HH:mm:ss z") Locale/US)
                              hour-ago)}
         state    (-> (session app)
                      (request "/expirable/set" :params params))]
@@ -183,7 +183,7 @@
                 "expired cookies should not be sent")))))
   (let [hour-ahead (t/from-now (t/hours 1))
         rfc822date (tf/unparse (:rfc822 tf/formatters) hour-ahead)
-        rfc850date (tf/unparse (tf/formatter "EEEE, dd-MMM-yy HH:mm:ss z")
+        rfc850date (tf/unparse (tf/with-locale (tf/formatter "EEEE, dd-MMM-yy HH:mm:ss z") Locale/US)
                                hour-ahead)
         params     {"rfc822" rfc822date, "rfc850" rfc850date}
         state      (-> (session app)


### PR DESCRIPTION
Currently, the date parsing logic will pick up the system locale and can
thus fail to parse dates in those circumstances.  In this PR, the parser
is forced into the US locale.  Additionally, the tests which are subject
to the same bug are fixed.

With help from Jake McCrary @jakemcc