### PR TITLE
Search for headers case insensitively

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Search headers case insensitively. [#40](https://github.com/xeqi/peridot/pull/40)
 * Drop support for Clojure 1.3 and 1.4. It appears that there was already a latent problem with Java 8 and 1.3/1.4, but it wasn't detected because CI was running against Java 7. [#41](https://github.com/xeqi/peridot/pull/41)
 * Parse dates independently from system locale, forcing parsing in the US locale. [#38](https://github.com/xeqi/peridot/pull/38)
 * Bump dependency versions. [#36](https://github.com/xeqi/peridot/pull/36)

--- a/src/peridot/cookie_jar.clj
+++ b/src/peridot/cookie_jar.clj
@@ -6,7 +6,8 @@
            (java.util Date Locale))
   (:require [clojure.string :as string]
             [clj-time.core :as t]
-            [clj-time.format :as tf]))
+            [clj-time.format :as tf]
+            [ring.util.response :as rur]))
 
 (def cookie-date-formats
   (map #(SimpleDateFormat. % Locale/US)
@@ -58,7 +59,7 @@
   (assoc cookie-jar  k v))
 
 (defn merge-cookies [headers cookie-jar uri host]
-  (let [cookie-string (get headers "Set-Cookie")]
+  (let [cookie-string (rur/get-header {:headers headers} "Set-Cookie")]
     (if (empty? cookie-string)
       cookie-jar
       (update-in cookie-jar [host] merge

--- a/src/peridot/request.clj
+++ b/src/peridot/request.clj
@@ -3,7 +3,8 @@
             [peridot.cookie-jar :as cj]
             [clojure.string :as string]
             [clojure.java.io :as io]
-            [ring.mock.request :as mock])
+            [ring.mock.request :as mock]
+            [ring.util.response :as rur])
   (:import java.io.ByteArrayInputStream))
 
 (defmulti to-input-stream class)
@@ -13,7 +14,7 @@
 (defmethod to-input-stream :default [x] (io/input-stream x))
 
 (defn get-host [request]
-  (string/lower-case (get (:headers request) "host")))
+  (string/lower-case (rur/get-header request "host")))
 
 (defn set-post-content-type [request]
   (if (and (not (:content-type request))


### PR DESCRIPTION
This will allow peridot to follow redirects when headers don't match title case.