### PR TITLE
Fix Travis script to not use lein2 alias

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,2 @@
 language: clojure
-lein: lein2
-script: lein2 all test
+script: lein all test

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject peridot "0.4.4"
+(defproject peridot "0.4.5-SNAPSHOT"
   :description "Interact with ring apps"
   :url "https://github.com/xeqi/peridot"
   :min-lein-version "2.0.0"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [;;Use clojure 1.3 for pom generation
-                 [org.clojure/clojure "1.3.0"]
+                 [org.clojure/clojure "1.5.1"]
                  [ring-mock "0.1.5"]
                  [org.clojure/data.codec "0.1.0"]
                  [org.apache.httpcomponents/httpmime "4.5.1"
@@ -23,14 +23,8 @@
                                    ^:replace [org.clojure/clojure "1.8.0"]]
                     :resource-paths ["test-resources"]}
              ;; use the relevant clojure version for testing
-             :1.3 {:dependencies [^:replace [org.clojure/clojure "1.3.0"]
-                                  ^:replace [clj-time "0.9.0"]
-                                  ^:replace [ring/ring-core "1.3.2"]]}
-             :1.4 {:dependencies [^:replace [org.clojure/clojure "1.4.0"]
-                                  ^:replace [clj-time "0.9.0"]
-                                  ^:replace [ring/ring-core "1.3.2"]]}
              :1.5 {:dependencies [^:replace [org.clojure/clojure "1.5.1"]]}
              :1.6 {:dependencies [^:replace [org.clojure/clojure "1.6.0"]]}
              :1.7 {:dependencies [^:replace [org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [^:replace [org.clojure/clojure "1.8.0"]]}}
-  :aliases {"all" ["with-profile" "+1.3:+1.4:+1.5:+1.6:+1.7:+1.8"]})
+  :aliases {"all" ["with-profile" "+1.5:+1.6:+1.7:+1.8"]})


### PR DESCRIPTION
This fails in Clojure 1.3 and 1.4 on CI and on my machine. I'm not sure why, or if it's worth tracking it down. The last [successful build](https://travis-ci.org/xeqi/peridot/builds/194027161) was run on Java 7 and Ubuntu Precise. Would it be OK to drop support for 1.3 and 1.4? 1.4 was released 5 years ago, I doubt there are many/if any people running that version still, and if they are I don't think it's unreasonable to ask them to upgrade Clojure versions to get a newer supported version of peridot.