### PR TITLE
Fix cookie jar to not partition by port

### DIFF
--- a/src/peridot/cookie_jar.clj
+++ b/src/peridot/cookie_jar.clj
@@ -53,8 +53,13 @@
 (defn ^:private set-cookie [cookie-jar [k v]]
   (assoc cookie-jar k v))
 
-(defn merge-cookies [headers cookie-jar uri host]
-  (let [cookie-string (rur/get-header {:headers headers} "Set-Cookie")]
+(defn merge-cookies
+  "Called when updating the session with the response"
+  ;; response-headers come from response
+  ;; cookie-jar comes from session
+  ;; uri and host come from request
+  [response-headers cookie-jar uri host]
+  (let [cookie-string (rur/get-header {:headers response-headers} "Set-Cookie")]
     (if (empty? cookie-string)
       cookie-jar
       (update-in cookie-jar [host] merge

--- a/test/peridot/test/request.clj
+++ b/test/peridot/test/request.clj
@@ -1,6 +1,6 @@
 (ns peridot.test.request
   (:require [clojure.test :refer :all]
-            [peridot.request :refer [url]]
+            [peridot.request :refer [url get-host]]
             [ring.mock.request :as mock]))
 
 (deftest url-generation
@@ -10,3 +10,23 @@
   (testing "it should include querystrings"
     (is (= "http://example.com:4000/fuzbats?a=1"
            (url (mock/request :get "http://example.com:4000/fuzbats?a=1"))))))
+
+(deftest get-host-test
+  (is (= "example.com" (get-host (mock/request :get "http://example.com"))))
+  (testing "port is ignored"
+    (is (= "example.com" (get-host (mock/request :get "http://example.com:4000/")))))
+  (testing "case is ignored"
+    (is (= "example.com" (get-host (mock/request :get "http://eXamPLE.CoM/")))))
+  (testing "IPv4 addresses"
+    (is (= "127.0.0.1" (get-host (mock/request :get "http://127.0.0.1"))))
+    (is (= "127.0.0.1" (get-host (mock/request :get "http://127.0.0.1:8080")))))
+  (testing "IPv6 addresses"
+    (is (= "[2001:db8:3333:4444:5555:6666:7777:8888]"
+           (get-host (mock/request :get "http://[2001:db8:3333:4444:5555:6666:7777:8888]/"))))
+    (is (= "[2001:db8:3333:4444:5555:6666:7777:8888]"
+           (get-host (mock/request :get "http://[2001:db8:3333:4444:5555:6666:7777:8888]:8080/"))))
+    (is (= "[2001:db8::]" (get-host (mock/request :get "http://[2001:db8::]"))))
+    (is (= "[2001:db8::]" (get-host (mock/request :get "http://[2001:db8::]:8080"))))
+    (testing "dual address"
+      (is (= "[2001:db8::123.123.123.123]"
+             (get-host (mock/request :get "http://[2001:db8::123.123.123.123]:8080/")))))))


### PR DESCRIPTION
HTTP cookies are shared across all ports on a host. Previously our
cookie jar would treat cookies set from the same host on different ports
separately. Now they are all handled the same.

https://stackoverflow.com/a/16328399

Fixes #51

@jeroenvandijk, could you take a look at this and let me know if it works for you?
